### PR TITLE
RE CVX v0.9.3.0

### DIFF
--- a/SRTPluginManager.cfg
+++ b/SRTPluginManager.cfg
@@ -179,8 +179,8 @@
  			"platform": 1,
  			"internalName": "Resident Evil: Code Veronica X",
  			"pluginName": "SRTPluginProviderRECVX",
- 			"currentVersion": "0.9.2.3",
- 			"downloadURL": "https://github.com/SpeedrunTooling/re-cvx-srt-provider/releases/download/0.9.2.3/SRTPluginProviderRECVX.zip",
+ 			"currentVersion": "0.9.3.0",
+ 			"downloadURL": "https://github.com/kapdap/re-cvx-srt-provider/releases/download/0.9.3.0/SRTPluginProviderRECVX-v0.9.3.0.zip",
  			"contributors": [
  				"Kapdap",
  				"Squirrelies",


### PR DESCRIPTION
RE CVX Provider plugin updated to v0.9.3.0
- Support PCSX2 1.7+
- Minor fixes