### PR TITLE
RE CVX Provider v0.9.3.1

### DIFF
--- a/SRTPluginManager.cfg
+++ b/SRTPluginManager.cfg
@@ -190,8 +190,8 @@
  			"platform": 1,
  			"internalName": "Resident Evil: Code Veronica X",
  			"pluginName": "SRTPluginProviderRECVX",
- 			"currentVersion": "0.9.3.0",
- 			"downloadURL": "https://github.com/kapdap/re-cvx-srt-provider/releases/download/0.9.3.0/SRTPluginProviderRECVX-v0.9.3.0.zip",
+ 			"currentVersion": "0.9.3.1",
+ 			"downloadURL": "https://github.com/kapdap/re-cvx-srt-provider/releases/download/0.9.3.1/SRTPluginProviderRECVX-v0.9.3.1.zip",
  			"contributors": [
  				"Kapdap",
  				"Squirrelies",


### PR DESCRIPTION
RE CVX Provider plugin updated to v0.9.3.1

- Support RPSC3 0.0.29-15508+
