### PR TITLE
Add SRTPluginProviderSH2C - Silent Hill 2 Classic

### DIFF
--- a/SRTPluginManager.cfg
+++ b/SRTPluginManager.cfg
@@ -247,6 +247,17 @@
  			]
  		},
  		{
+            "platform": 0,
+            "internalName": "Silent Hill 2 Classic",
+            "pluginName": "SRTPluginProviderSH2C",
+            "currentVersion": "1.0.1.0",
+            "downloadURL": "https://github.com/ARESaurio/SRTPluginProviderSH2C/releases/download/v1.0.1.0/SRTPluginProviderSH2C.zip",
+            "contributors": [ 
+				"ARESaurio", 
+				"Miguel_mm_95"
+            ]
+        },
+		{
  			"platform": 1,
  			"internalName": "Silent Hill 2 Remake",
  			"pluginName": "SRTPluginProviderSH2R",


### PR DESCRIPTION
Adds memory provider plugin for Silent Hill 2 Classic (PC, 2001).
- Platform: x86 (32-bit)
- Tracks: HP, IGT, weapons/ammo, run stats, difficulty
- Repo: https://github.com/ARESaurio/SRTPluginProviderSH2C