### PR TITLE
Update SRTPluginProviderSH2C to v1.0.2.0

### DIFF
--- a/SRTPluginManager.cfg
+++ b/SRTPluginManager.cfg
@@ -250,8 +250,8 @@
             "platform": 0,
             "internalName": "Silent Hill 2 Classic",
             "pluginName": "SRTPluginProviderSH2C",
-            "currentVersion": "1.0.1.0",
-            "downloadURL": "https://github.com/ARESaurio/SRTPluginProviderSH2C/releases/download/v1.0.1.0/SRTPluginProviderSH2C.zip",
+            "currentVersion": "1.0.2.0",
+			"downloadURL": "https://github.com/ARESaurio/SRTPluginProviderSH2C/releases/download/v1.0.2.0/SRTPluginProviderSH2C.zip",
             "contributors": [ 
 				"ARESaurio", 
 				"Miguel_mm_95"


### PR DESCRIPTION
Updates SH2C plugin to v1.0.2.0:
- Added Silent Hill 2 Enhanced Edition support
- Boat time now displays milliseconds