### PR TITLE
add SRTPluginProviderSH1 (Silent Hill 1 Classic)

### DIFF
--- a/SRTPluginManager.cfg
+++ b/SRTPluginManager.cfg
@@ -246,6 +246,16 @@
  				"Squirrelies"
  			]
  		},
+		{
+            "platform": 0,
+            "internalName": "Silent Hill 1 Classic",
+            "pluginName": "SRTPluginProviderSH1",
+            "currentVersion": "1.0.0.0",
+			"downloadURL": "https://github.com/ARESaurio/SRTPluginProviderSH1/releases/download/v1.0.0.0/SRTPluginProviderSH1.zip",
+            "contributors": [ 
+				"ARESaurio"
+            ]
+        },
  		{
             "platform": 0,
             "internalName": "Silent Hill 2 Classic",


### PR DESCRIPTION
Adds Silent Hill 1 Classic (SLUS-00707 / NTSC-U) running on DuckStation x64.

**Features (v1.0.0.0):**
- In-Game Time (IGT)
- HP status — Fine / Caution / Danger (0-100%)
- Save count

**Repo:** https://github.com/ARESaurio/SRTPluginProviderSH1
